### PR TITLE
add undef to the syntax as a builtin special

### DIFF
--- a/syntax/openscad-help.vim
+++ b/syntax/openscad-help.vim
@@ -111,7 +111,7 @@ syn keyword openscadBuiltin lookup max min pow rands round sign sin sqrt tan
 syn keyword openscadBuiltin str len search version version_num concat chr ord cross norm
 syn keyword openscadBuiltin parent_module
 syn keyword openscadBuiltin dxf_cross dxf_dim
-syn keyword openscadBuiltinSpecial PI
+syn keyword openscadBuiltinSpecial PI undef
 """""""""""""""""""""""""""""""""""""""""
 " linkage
 """""""""""""""""""""""""""""""""""""""""

--- a/syntax/openscad.vim
+++ b/syntax/openscad.vim
@@ -112,7 +112,7 @@ syn keyword openscadBuiltin lookup max min pow rands round sign sin sqrt tan
 syn keyword openscadBuiltin str len search version version_num concat chr ord cross norm
 syn keyword openscadBuiltin parent_module
 syn keyword openscadBuiltin dxf_cross dxf_dim
-syn keyword openscadBuiltinSpecial PI
+syn keyword openscadBuiltinSpecial PI undef
 
 """""""""""""""""""""""""""""""""""""""""
 " linkage


### PR DESCRIPTION
Thank you for maintaining this great plugin!

I've noticed undef isn't recognized by the syntax file so I've added it as a builtin special value comparable to PI.
(undef and PI are grouped in the same section on the wiki here https://openscad.org/cheatsheet/index.html )