### PR TITLE
Add missing rotate_extrude function name in snippets

### DIFF
--- a/lua/openscad/snippets/openscad.lua
+++ b/lua/openscad/snippets/openscad.lua
@@ -129,7 +129,7 @@ return {
 	}),
 
 	s({trig="rotate_extrude", dscr={"Rotate Extrude", "Rotational extrusion spins a 2D shape around the Z-axis to form a solid which has rotational symmetry."}}, {
-		t("angle="),
+		t("rotate_extrude(angle="),
 		i(1, "360"), t(", "),
 		t("convexity = "),
 		i(2, "2"),


### PR DESCRIPTION
This PR add the missing `rotate_extrude` function name in the relevant snippet.