### PR TITLE
Fix: OpenscadExecFile fails on file paths with spaces

### DIFF
--- a/lua/openscad.lua
+++ b/lua/openscad.lua
@@ -119,13 +119,14 @@ end
 
 function M.exec_openscad()
 	local jobCommand;
+	local filename = '"' .. vim.fn.expand("%:p") .. '"'
 
 	-- If Linux, just use basecommand, if on MacOS, use a special command
 	if vim.fn.has('mac') == 1 then
-		jobCommand = '/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD ' .. vim.fn.expand('%:p')
+		jobCommand = '/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD ' .. filename
 	else
 		-- TODO: What about Windows?
-		jobCommand = 'openscad ' .. vim.fn.expand('%:p')
+		jobCommand = 'openscad ' .. filename
 	end
 
 	vim.fn.jobstart(jobCommand)


### PR DESCRIPTION
Adds quotation marks around filename during Exec
Closes #22

Tested on updated Arch Linux and MacOS systems