### PR TITLE
Added comment string for openscad files

### DIFF
--- a/lua/openscad.lua
+++ b/lua/openscad.lua
@@ -66,6 +66,8 @@ function M.setup()
     vim.g.openscad_cheatsheet_window_blend = vim.g.openscad_cheatsheet_window_blend or 15 -- %
     vim.g.openscad_fuzzy_finder = vim.g.openscad_fuzzy_finder or 'skim'
     vim.g.openscad_load_snippets = vim.g.openscad_load_snippets or false
+    vim.bo.commentstring = '//%s'
+
 end
 
 function M.load()


### PR DESCRIPTION
This makes it so you can use the Neovim built-in commenting mechanism or [Comment.nvim](https://github.com/numToStr/Comment.nvim)