### PR TITLE
feat(pdf command): add option to change pdf viewer + fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Nvim >= 0.5
 
 Run `:checkhealth` to see if you fulfill the dependencies and requirements.
 
-- [zathura](https://github.com/pwmt/zathura)
+- [zathura](https://github.com/pwmt/zathura) or another pdf viewer
 - [skim](https://github.com/lotabout/skim.vim) or [fzf](https://github.com/junegunn/fzf.vim)
 - [htop](https://htop.dev)
 - [LuaSnip](https://github.com/L3MON4D3/LuaSnip)(optional)
@@ -61,7 +61,7 @@ Fuzzy find help resource
 ![help](https://oddodd.org/openscad.nvim-assets/help-gifsicled.gif)
 
 `<A-m>` in normal mode
-Open offline openscad manual in pdf via `zathura`
+Open offline openscad manual in pdf via pdf command (if one is set)
 ![manual](https://oddodd.org/openscad.nvim-assets/manual-gifsicled.gif)
 
 `<A-o>` in normal mode
@@ -77,6 +77,8 @@ toggle `htop` filtered for openscad processes
 These are the defaults:
 ```lua
 vim.g.openscad_fuzzy_finder = 'skim'
+-- when the pdf_command is run, the last argument will be the pdf filename
+vim.g.openscad_pdf_command = ''
 vim.g.openscad_cheatsheet_window_blend = 15 --%
 vim.g.openscad_load_snippets = false
 -- should the openscad project automatically be opened on startup
@@ -95,7 +97,7 @@ The default mappings are:
 ```lua
 vim.g.openscad_cheatsheet_toggle_key = '<Enter>'
 vim.g.openscad_help_trig_key = '<A-h>'
-vim.g.openscad_help_manual_trig_key = '<A-m>'
+vim.g.openscad_manual_trig_key = '<A-m>'
 vim.g.openscad_exec_openscad_trig_key = '<A-o>'
 vim.g.openscad_top_toggle = '<A-c>'
 ```

--- a/autoload/health/openscad_nvim.vim
+++ b/autoload/health/openscad_nvim.vim
@@ -6,14 +6,6 @@ function! s:check_nvim_version_minimum() abort
 	endif
 endfunction
 
-function! s:check_zathura_installed() abort
-	if !executable('zathura')
-		call v:lua.vim.health.error('has(zathura)','install zathura')
-	else
-		call v:lua.vim.health.ok("zathura is installed")
-	endif
-endfunction
-
 function! s:check_htop_installed() abort
 	if !executable('htop')
 		call v:lua.vim.health.error('has(htop)','install htop')

--- a/lua/openscad.lua
+++ b/lua/openscad.lua
@@ -66,6 +66,7 @@ function M.setup()
     vim.g.openscad_cheatsheet_window_blend = vim.g.openscad_cheatsheet_window_blend or 15 -- %
     vim.g.openscad_fuzzy_finder = vim.g.openscad_fuzzy_finder or 'skim'
     vim.g.openscad_load_snippets = vim.g.openscad_load_snippets or false
+    vim.g.openscad_pdf_command = vim.g.openscad_pdf_command or ''
     vim.bo.commentstring = '//%s'
 
 end
@@ -103,7 +104,11 @@ end
 
 function M.manual()
     local path = U.openscad_nvim_root_dir .. U.path_sep .. "help_source" .. U.path_sep .. "openscad-manual.pdf"
-    api.nvim_command('silent !zathura --fork '  .. path)
+    if vim.g.openscad_pdf_command == '' then
+        print("openscad.nvim: pdf command is not set.. please set a pdf command")
+    else
+        api.nvim_command('silent !' .. vim.g.openscad_pdf_command .. ' ' .. path)
+    end
 end
 
 function M.help()


### PR DESCRIPTION
This adds the config option `vim.g.openscad_pdf_command`, which allows for the use of pdf viewers other than zathura, it also removes the healthcheck for zathura and sets the default viewer to ''.

The default viewer being '' might cause problems for people who currently use zathura, as it would break their setup. However, trying to view the manual without setting a pdf viewer causes a warning, so I think it's fine.

This pr also fixes an issue where the readme claims that `vim.g.openscad_help_manual_trig_key` is the config value for the manual opening keybind, when it is actually `vim.g.openscad_manual_trig_key`.