### PR TITLE
Fix zathura checkhealth and support for snacks.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Nvim >= 0.5
 Run `:checkhealth` to see if you fulfill the dependencies and requirements.
 
 - [zathura](https://github.com/pwmt/zathura) or another pdf viewer
-- [skim](https://github.com/lotabout/skim.vim) or [fzf](https://github.com/junegunn/fzf.vim)
+- [skim](https://github.com/lotabout/skim.vim), [fzf](https://github.com/junegunn/fzf.vim) or [snacks.nvim](https://github.com/folke/snacks.nvim/blob/main/docs/picker.md)
 - [htop](https://htop.dev)
 - [LuaSnip](https://github.com/L3MON4D3/LuaSnip)(optional)
 

--- a/autoload/health/openscad_nvim.vim
+++ b/autoload/health/openscad_nvim.vim
@@ -16,7 +16,7 @@ endfunction
 
 function! s:check_zathura_installed() abort
 	if !executable('zathura')
-		call v:lua.vim.health.error('has(zathura)','install htop')
+		call v:lua.vim.health.error('has(zathura)','install zathura')
 	else
 		call v:lua.vim.health.ok("zathura is installed")
 	endif

--- a/autoload/health/openscad_nvim.vim
+++ b/autoload/health/openscad_nvim.vim
@@ -19,6 +19,16 @@ function! s:check_fuzzy_finder() abort
 		call v:lua.vim.health.ok('skim.vim is installed')
 	elseif match(&runtimepath, 'fzf.vim') != -1
 		call v:lua.vim.health.ok('fzf.vim is installed')
+	elseif match(&runtimepath, 'snacks.nvim') != -1
+    try
+        if luaeval("pcall(function() local s = require('snacks'); return s.picker ~= nil end)") 
+            call v:lua.vim.health.ok('snacks.nvim is installed and picker is available')
+        else
+            call v:lua.vim.health.warn('snacks.nvim is installed but picker is missing')
+        endif
+    catch
+        call v:lua.vim.health.error('No fuzzy finder :( install skim.vim, fzf.vim, or snacks.nvim')
+    endtry
 	else
 		call v:lua.vim.health.error('No fuzzy finder :( install skim.vim or fzf.vim')
 	endif

--- a/autoload/health/openscad_nvim.vim
+++ b/autoload/health/openscad_nvim.vim
@@ -14,6 +14,14 @@ function! s:check_htop_installed() abort
 	endif
 endfunction
 
+function! s:check_zathura_installed() abort
+	if !executable('zathura')
+		call v:lua.vim.health.error('has(zathura)','install htop')
+	else
+		call v:lua.vim.health.ok("zathura is installed")
+	endif
+endfunction
+
 function! s:check_fuzzy_finder() abort
 	if match(&runtimepath, 'skim.vim') != -1
 		call v:lua.vim.health.ok('skim.vim is installed')

--- a/lua/openscad.lua
+++ b/lua/openscad.lua
@@ -119,6 +119,15 @@ function M.help()
     elseif vim.g.openscad_fuzzy_finder == 'fzf' then
         api.nvim_command('silent FZF '  .. path)
         print("fzf openscad help")
+    elseif vim.g.openscad_fuzzy_finder == 'snacks' then
+        local snacks = require 'snacks'
+        snacks.picker.files {
+          prompt = 'OpenSCAD Help>',
+          cwd = path,
+          layout = 'ivy',
+          preview = nil,
+        }
+        print("snacks openscad help")
     else
         print("openscad.nvim: this fuzzy finder (" .. vim.g.openscad_fuzzy_finder .. ") i dont know.. plz use 'skim' or 'fzf'")
     end

--- a/lua/openscad.lua
+++ b/lua/openscad.lua
@@ -127,7 +127,7 @@ function M.help()
         }
         print("snacks openscad help")
     else
-        print("openscad.nvim: this fuzzy finder (" .. vim.g.openscad_fuzzy_finder .. ") i dont know.. plz use 'skim' or 'fzf'")
+        print("openscad.nvim: this fuzzy finder (" .. vim.g.openscad_fuzzy_finder .. ") i dont know.. plz use 'skim', 'fzf' or 'snacks'")
     end
 end
 

--- a/lua/openscad.lua
+++ b/lua/openscad.lua
@@ -122,10 +122,8 @@ function M.help()
     elseif vim.g.openscad_fuzzy_finder == 'snacks' then
         local snacks = require 'snacks'
         snacks.picker.files {
-          prompt = 'OpenSCAD Help>',
-          cwd = path,
-          layout = 'ivy',
-          preview = nil,
+            prompt = 'OpenSCAD Help>',
+            cwd = path,
         }
         print("snacks openscad help")
     else


### PR DESCRIPTION
Just bought a 3d printer, and wanted to use nvim. Saw this plugin, and decided to download it, but ran into some issues.

- fzf.vim and skim.vim have been updated such that FZF command and SK command are not available. I have not tackled this issue here as I use snacks.
- Zathura checkhealth did not have the function defined, so I added it to this PR.
- I wanted support for the snacks.nvim picker, so I have added that support here, and changed the documentation to reflect the option.

I am quite new to the lua scene and this is one of my first opensource PRs. If there are some changes that you would like, then feel free to let me know. From my testing this seems to work.

Best,
Simon